### PR TITLE
Switch to parent class kill track method and remove unused boolean members

### DIFF
--- a/include/DDML/FastMLShower.h
+++ b/include/DDML/FastMLShower.h
@@ -129,11 +129,9 @@ public:
   /// User callback to model the particle/energy shower - details defined in
   /// ML_MODEL
   virtual void modelShower(const G4FastTrack& track, G4FastStep& step) override {
-    // remove particle from further processing by G4
-    step.KillPrimaryTrack();
-    step.ProposePrimaryTrackPathLength(0.0);
     G4double energy = track.GetPrimaryTrack()->GetKineticEnergy();
-    step.ProposeTotalEnergyDeposited(energy);
+    // remove particle from further processing by G4
+    killParticle(step, energy);
 
 #if DDML_INSTRUMENT_MODEL_SHOWER
     podio::UserDataCollection<double> prepareInputTime;

--- a/include/DDML/FastMLShower.h
+++ b/include/DDML/FastMLShower.h
@@ -81,24 +81,18 @@ public:
 
   /// Geometry construction callback. Called at "Construct()"
   virtual void constructGeo(dd4hep::sim::Geant4DetectorConstructionContext* ctxt) override {
-    // if( fastsimML.has_constructGeo )      fastsimML.constructGeo( ctxt ) ;
-    // else
     this->Geant4FastSimShowerModel::constructGeo(ctxt);
   }
 
   /// Electromagnetic field construction callback. Called at
   /// "ConstructSDandField()"
   virtual void constructField(dd4hep::sim::Geant4DetectorConstructionContext* ctxt) override {
-    // if( fastsimML.has_constructField )      fastsimML.constructField( ctxt )
-    // ; else
     this->Geant4FastSimShowerModel::constructField(ctxt);
   }
 
   /// Sensitive detector construction callback. Called at
   /// "ConstructSDandField()"
   virtual void constructSensitives(dd4hep::sim::Geant4DetectorConstructionContext* ctxt) override {
-    // if( fastsimML.has_constructSensitives ) fastsimML.constructSensitives(
-    // ctxt ) ; else
     this->Geant4FastSimShowerModel::constructSensitives(ctxt);
   }
 
@@ -108,8 +102,6 @@ public:
    * 'ApplicableParticles'
    */
   virtual bool check_applicability(const G4ParticleDefinition& particle) override {
-    // if( fastsimML.has_check_applicability )   return
-    // fastsimML.check_applicability(particle) ; else
     return this->Geant4FastSimShowerModel::check_applicability(particle);
   }
 
@@ -118,8 +110,6 @@ public:
    * 'Etrigger' the kinetic energy is bigger than the value.
    */
   virtual bool check_trigger(const G4FastTrack& track) override {
-    // if( fastsimML.has_check_trigger ) return fastsimML.check_trigger(track )
-    // ; else
     if (this->Geant4FastSimShowerModel::check_trigger(track)) {
       return m_fastsimML.trigger.check_trigger(track);
     }
@@ -225,12 +215,6 @@ struct FastMLModel {
   Trigger trigger{};
 
   FastMLModel() : hitMaker(new HitMaker) {}
-
-  const bool has_constructGeo = false;
-  const bool has_constructField = false;
-  const bool has_constructSensitives = false;
-  const bool has_check_applicability = false;
-  const bool has_check_trigger = false;
 
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
     model.declareProperties(plugin);


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to the `Geant4FastSimShowerModel::killParticle` method instead of re-implementing it
- Remove unused boolean members that were remnants from a previous design

ENDRELEASENOTES
