### PR TITLE
Make all abstract base class interfaces concepts and use them instead

### DIFF
--- a/include/DDML/CaloCloudsTwoAngleModel.h
+++ b/include/DDML/CaloCloudsTwoAngleModel.h
@@ -1,8 +1,9 @@
 #ifndef CaloCloudsTwoAngleModel_H
 #define CaloCloudsTwoAngleModel_H
 
-#include "DDML/FastMLShower.h"
 #include "DDML/ModelInterface.h"
+
+#include <DDG4/Geant4Action.h>
 
 namespace ddml {
 
@@ -18,11 +19,11 @@ namespace ddml {
  *  @date May. 2024
  */
 
-class CaloCloudsTwoAngleModel : public ModelInterface {
+class CaloCloudsTwoAngleModel {
 public:
   CaloCloudsTwoAngleModel() = default;
 
-  virtual ~CaloCloudsTwoAngleModel() = default;
+  ~CaloCloudsTwoAngleModel() = default;
 
   /// declare the proerties needed for the plugin
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
@@ -33,13 +34,13 @@ public:
    *  based on the current FastTrack (e.g. extract kinetic energy and incident
    *  angles.)
    */
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output);
+  void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                    TensorDimVecs& tensDims, std::vector<float>& output);
 
   /** create a vector of spacepoints per layer interpreting the model output
    */
-  virtual void convertOutput(G4FastTrack const&, G4ThreeVector const&, const std::vector<float>& output,
-                             std::vector<SpacePointVec>& spacepoints);
+  void convertOutput(G4FastTrack const&, G4ThreeVector const&, const std::vector<float>& output,
+                     std::vector<SpacePointVec>& spacepoints);
 
 private:
   /// model properties for plugin
@@ -60,6 +61,8 @@ private:
 
   TensorDimVecs m_tensDims = {{1, 1}, {1, 1}, {1, 1}, {1, 3}};
 };
+
+static_assert(ModelInterface<CaloCloudsTwoAngleModel>, "CaloCloudsTwoAngleModel must fulfill the ModelInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/CaloCloudsTwoAngleModel.h
+++ b/include/DDML/CaloCloudsTwoAngleModel.h
@@ -62,7 +62,8 @@ private:
   TensorDimVecs m_tensDims = {{1, 1}, {1, 1}, {1, 1}, {1, 3}};
 };
 
-static_assert(ModelInterface<CaloCloudsTwoAngleModel>, "CaloCloudsTwoAngleModel must fulfill the ModelInterface concept");
+static_assert(ModelInterface<CaloCloudsTwoAngleModel>,
+              "CaloCloudsTwoAngleModel must fulfill the ModelInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/EndcapGeometry.h
+++ b/include/DDML/EndcapGeometry.h
@@ -14,7 +14,7 @@ namespace ddml {
  *  @date Mar 2023
  */
 
-class EndcapGeometry : public GeometryInterface {
+class EndcapGeometry {
 public:
   EndcapGeometry() { initialize(); };
 
@@ -36,7 +36,7 @@ public:
 
   /** convert the local spacepoints to global spacepoints
    */
-  virtual void localToGlobal(G4FastTrack const& aFastTrack, std::vector<SpacePointVec>& spacepoints) const;
+  void localToGlobal(G4FastTrack const& aFastTrack, std::vector<SpacePointVec>& spacepoints) const;
 
 private:
   std::vector<float> m_caloLayerDistances = {};
@@ -45,6 +45,9 @@ private:
   std::string m_detector = {"EcalEndcap"};
   bool m_correctForAngles = false;
 };
+
+// Static assert to ensure EndcapGeometry models the GeometryInterface concept
+static_assert(GeometryInterface<EndcapGeometry>, "EndcapGeometry should model the GeometryInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/EndcapTriggerTwoAngleBIBAE.h
+++ b/include/DDML/EndcapTriggerTwoAngleBIBAE.h
@@ -16,16 +16,19 @@ namespace ddml {
  *
  */
 
-class EndcapTriggerTwoAngleBIBAE : public TriggerInterface {
+class EndcapTriggerTwoAngleBIBAE {
 public:
   EndcapTriggerTwoAngleBIBAE() = default;
 
-  virtual ~EndcapTriggerTwoAngleBIBAE() = default;
+  ~EndcapTriggerTwoAngleBIBAE() = default;
 
   // check trigger
-
-  virtual bool check_trigger(const G4FastTrack& aFastTrack);
+  bool check_trigger(const G4FastTrack& aFastTrack) const;
 };
+
+// Ensure this class models the TriggerInterface concept
+static_assert(TriggerInterface<EndcapTriggerTwoAngleBIBAE>,
+              "EndcapTriggerTwoAngleBIBAE should model the TriggerInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/FastMLShower.h
+++ b/include/DDML/FastMLShower.h
@@ -11,6 +11,7 @@
 #include "DDML/DDML.h"
 #include "DDML/InferenceInterface.h"
 #include "DDML/ModelInterface.h"
+#include "DDML/TriggerInterface.h"
 
 #ifndef DDML_INSTRUMENT_MODEL_SHOWER
 #define DDML_INSTRUMENT_MODEL_SHOWER 0
@@ -194,8 +195,9 @@ public:
 };
 
 struct AlwaysTrueTrigger {
-  bool check_trigger(const G4FastTrack&) { return true; }
+  bool check_trigger(const G4FastTrack&) const { return true; }
 };
+static_assert(TriggerInterface<AlwaysTrueTrigger>, "AlwaysTrueTrigger should model the TriggerInterface concept");
 
 /** Template class to put together a complete ML model by specifying
  * implementations for the Inference, the Model, the Geometry and a HitMaker.
@@ -204,7 +206,7 @@ struct AlwaysTrueTrigger {
  * @date Mar 2023
  */
 template <InferenceInterface Inference, ModelInterface MLModel, class Geometry, class HitMaker,
-          class Trigger = AlwaysTrueTrigger>
+          TriggerInterface Trigger = AlwaysTrueTrigger>
 struct FastMLModel {
   using InferenceT = Inference;
   using MLModelT = MLModel;

--- a/include/DDML/FastMLShower.h
+++ b/include/DDML/FastMLShower.h
@@ -9,6 +9,7 @@
 #include <G4Track.hh>
 
 #include "DDML/DDML.h"
+#include "DDML/GeometryInterface.h"
 #include "DDML/InferenceInterface.h"
 #include "DDML/ModelInterface.h"
 #include "DDML/TriggerInterface.h"
@@ -205,7 +206,7 @@ static_assert(TriggerInterface<AlwaysTrueTrigger>, "AlwaysTrueTrigger should mod
  * @author F.Gaede, DESY
  * @date Mar 2023
  */
-template <InferenceInterface Inference, ModelInterface MLModel, class Geometry, class HitMaker,
+template <InferenceInterface Inference, ModelInterface MLModel, GeometryInterface Geometry, class HitMaker,
           TriggerInterface Trigger = AlwaysTrueTrigger>
 struct FastMLModel {
   using InferenceT = Inference;

--- a/include/DDML/FastMLShower.h
+++ b/include/DDML/FastMLShower.h
@@ -9,6 +9,7 @@
 #include <G4Track.hh>
 
 #include "DDML/DDML.h"
+#include "DDML/Geant4FastHitMakerGlobal.h"
 #include "DDML/GeometryInterface.h"
 #include "DDML/InferenceInterface.h"
 #include "DDML/ModelInterface.h"
@@ -25,6 +26,7 @@
 
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <numeric>
 
 using ClockT = std::chrono::high_resolution_clock;
@@ -206,21 +208,20 @@ static_assert(TriggerInterface<AlwaysTrueTrigger>, "AlwaysTrueTrigger should mod
  * @author F.Gaede, DESY
  * @date Mar 2023
  */
-template <InferenceInterface Inference, ModelInterface MLModel, GeometryInterface Geometry, class HitMaker,
+template <InferenceInterface Inference, ModelInterface MLModel, GeometryInterface Geometry,
           TriggerInterface Trigger = AlwaysTrueTrigger>
 struct FastMLModel {
   using InferenceT = Inference;
   using MLModelT = MLModel;
   using GeometryT = Geometry;
-  using HitMakerT = HitMaker;
 
   Inference inference = {};
   MLModel model = {};
   Geometry geometry = {};
-  HitMaker* hitMaker = {};
+  std::unique_ptr<Geant4FastHitMakerGlobal> hitMaker = {};
   Trigger trigger{};
 
-  FastMLModel() : hitMaker(new HitMaker) {}
+  FastMLModel() : hitMaker(std::make_unique<Geant4FastHitMakerGlobal>()) {}
 
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
     model.declareProperties(plugin);

--- a/include/DDML/FastMLShower.h
+++ b/include/DDML/FastMLShower.h
@@ -9,6 +9,7 @@
 #include <G4Track.hh>
 
 #include "DDML/DDML.h"
+#include "DDML/InferenceInterface.h"
 #include "DDML/ModelInterface.h"
 
 #ifndef DDML_INSTRUMENT_MODEL_SHOWER
@@ -202,7 +203,8 @@ struct AlwaysTrueTrigger {
  * @author F.Gaede, DESY
  * @date Mar 2023
  */
-template <class Inference, ModelInterface MLModel, class Geometry, class HitMaker, class Trigger = AlwaysTrueTrigger>
+template <InferenceInterface Inference, ModelInterface MLModel, class Geometry, class HitMaker,
+          class Trigger = AlwaysTrueTrigger>
 struct FastMLModel {
   using InferenceT = Inference;
   using MLModelT = MLModel;

--- a/include/DDML/FastMLShower.h
+++ b/include/DDML/FastMLShower.h
@@ -9,6 +9,7 @@
 #include <G4Track.hh>
 
 #include "DDML/DDML.h"
+#include "DDML/ModelInterface.h"
 
 #ifndef DDML_INSTRUMENT_MODEL_SHOWER
 #define DDML_INSTRUMENT_MODEL_SHOWER 0
@@ -201,7 +202,7 @@ struct AlwaysTrueTrigger {
  * @author F.Gaede, DESY
  * @date Mar 2023
  */
-template <class Inference, class MLModel, class Geometry, class HitMaker, class Trigger = AlwaysTrueTrigger>
+template <class Inference, ModelInterface MLModel, class Geometry, class HitMaker, class Trigger = AlwaysTrueTrigger>
 struct FastMLModel {
   using InferenceT = Inference;
   using MLModelT = MLModel;

--- a/include/DDML/GeometryInterface.h
+++ b/include/DDML/GeometryInterface.h
@@ -1,6 +1,7 @@
 #ifndef GeometryInterface_H
 #define GeometryInterface_H
 
+#include <concepts>
 #include <vector>
 
 #include <G4ThreeVector.hh>
@@ -11,7 +12,7 @@ class G4FastTrack;
 
 namespace ddml {
 
-/** The basic interface for the detector geometry - converting between global
+/** The basic concept for the detector geometry - converting between global
  * (envelope) and local coordinates. The convention for the local coordinate
  * system is a right-handed coordinate system that has the z-axis pointing into
  *  the calorimeter, normal to the calorimeter planes.
@@ -20,20 +21,19 @@ namespace ddml {
  *  @date Mar 2023
  */
 
-class GeometryInterface {
-public:
-  virtual ~GeometryInterface() = default;
+template <typename T>
+concept GeometryInterface =
+    requires(const T t, const G4FastTrack& aFastTrack, std::vector<SpacePointVec>& spacepoints) {
+      /** compute local direction in coordinate system that has the z-axis pointing
+       * into the calorimeter, normal to the layers
+       */
+      { t.localDirection(aFastTrack) } -> std::same_as<G4ThreeVector>;
 
-  /** compute local direction in coordinate system that has the z-axis pointing
-   * into the calorimeter, normal to the layers
-   */
-  virtual G4ThreeVector localDirection(G4FastTrack const& aFastTrack) const = 0;
-
-  /** convert the local spacepoints to global spacepoints inside sensitive
-   * volumes
-   */
-  virtual void localToGlobal(G4FastTrack const& aFastTrack, std::vector<SpacePointVec>& spacepoints) const = 0;
-};
+      /** convert the local spacepoints to global spacepoints inside sensitive
+       * volumes
+       */
+      { t.localToGlobal(aFastTrack, spacepoints) } -> std::same_as<void>;
+    };
 
 } // namespace ddml
 

--- a/include/DDML/InferenceInterface.h
+++ b/include/DDML/InferenceInterface.h
@@ -3,8 +3,8 @@
 
 #include "DDML/DDML.h"
 
-#include <vector>
 #include <concepts>
+#include <vector>
 
 namespace ddml {
 
@@ -15,11 +15,12 @@ namespace ddml {
  *  @date Mar 2023
  */
 
-template<typename T>
-concept InferenceInterface = requires(T t, const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output) {
-  /// run the inference model - based on input vector and resized outputvector
-  { t.runInference(inputs, tensDims, output) } -> std::same_as<void>;
-};
+template <typename T>
+concept InferenceInterface =
+    requires(T t, const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output) {
+      /// run the inference model - based on input vector and resized outputvector
+      { t.runInference(inputs, tensDims, output) } -> std::same_as<void>;
+    };
 
 } // namespace ddml
 

--- a/include/DDML/InferenceInterface.h
+++ b/include/DDML/InferenceInterface.h
@@ -18,7 +18,7 @@ namespace ddml {
 template<typename T>
 concept InferenceInterface = requires(T t, const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output) {
   /// run the inference model - based on input vector and resized outputvector
-  t.runInference(inputs, tensDims, output);
+  { t.runInference(inputs, tensDims, output) } -> std::same_as<void>;
 };
 
 } // namespace ddml

--- a/include/DDML/InferenceInterface.h
+++ b/include/DDML/InferenceInterface.h
@@ -4,22 +4,21 @@
 #include "DDML/DDML.h"
 
 #include <vector>
+#include <concepts>
 
 namespace ddml {
 
-/** The basic interface for running inference with one input vector and one
+/** The basic concept for running inference with one input vector and one
  * output vector.
  *
  *  @author F.Gaede, DESY
  *  @date Mar 2023
  */
 
-class InferenceInterface {
-public:
-  virtual ~InferenceInterface() = default;
-
+template<typename T>
+concept InferenceInterface = requires(T t, const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output) {
   /// run the inference model - based on input vector and resized outputvector
-  virtual void runInference(const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output) = 0;
+  t.runInference(inputs, tensDims, output);
 };
 
 } // namespace ddml

--- a/include/DDML/L2LFlowsModel.h
+++ b/include/DDML/L2LFlowsModel.h
@@ -16,11 +16,11 @@ namespace ddml {
  *  @author Th. Buss, Uni Hamburg
  *  @date Aug. 2024
  */
-class L2LFlowsModel : public ModelInterface {
+class L2LFlowsModel {
 public:
   L2LFlowsModel() = default;
 
-  virtual ~L2LFlowsModel() = default;
+  ~L2LFlowsModel() = default;
 
   /// declare the proerties needed for the plugin
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
@@ -41,13 +41,13 @@ public:
    *  based on the current FastTrack (e.g. extract kinetic energy and incident
    *  angles.)
    */
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output);
+  void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                    TensorDimVecs& tensDims, std::vector<float>& output);
 
   /** create a vector of spacepoints per layer interpreting the model output
    */
-  virtual void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir,
-                             const std::vector<float>& output, std::vector<SpacePointVec>& spacepoints);
+  void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, const std::vector<float>& output,
+                     std::vector<SpacePointVec>& spacepoints);
 
 private:
   /// model properties for plugin
@@ -63,5 +63,6 @@ private:
   TensorDimVecs m_tensDims = {{1, 4}};
 };
 
+static_assert(ModelInterface<L2LFlowsModel>, "L2LFlowsModel must fulfill the ModelInterface concept");
 } // namespace ddml
 #endif

--- a/include/DDML/LoadHdf5.h
+++ b/include/DDML/LoadHdf5.h
@@ -22,7 +22,7 @@ namespace ddml {
  *  @date  Sep. 2024
  */
 
-class LoadHdf5 : public InferenceInterface {
+class LoadHdf5 {
 public:
   LoadHdf5() = default;
 
@@ -35,7 +35,7 @@ public:
   void initialize();
 
   /// run the inference model - based on input vector and resized outputvector
-  void runInference(const InputVecs&, const TensorDimVecs&, std::vector<float>& output) override;
+  void runInference(const InputVecs&, const TensorDimVecs&, std::vector<float>& output);
 
 private:
   H5::H5File m_file = 0;
@@ -60,6 +60,8 @@ private:
   // counter to keep track of location in file
   uint32_t m_count{0};
 };
+
+static_assert(InferenceInterface<LoadHdf5>, "LoadHdf5 must satisfy InferenceInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/ModelInterface.h
+++ b/include/DDML/ModelInterface.h
@@ -2,6 +2,7 @@
 #define ModelInterface_H
 
 #include <vector>
+#include <concepts>
 
 #include "DDML/DDML.h"
 
@@ -16,26 +17,22 @@ namespace ddml {
  *  @author F.Gaede, DESY
  *  @date Mar 2023
  */
-
-class ModelInterface {
-public:
-  virtual ~ModelInterface() = default;
-
+template<typename T>
+concept ModelInterface = requires(T t, G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, 
+                                  InputVecs& inputs, TensorDimVecs& tensDims, std::vector<float>& output,
+                                  const std::vector<float>& constOutput, std::vector<SpacePointVec>& spacepoints) {
   /** prepare the input vector and resize the output vector for this model
    *  based on the current FastTrack (e.g. extract kinetic energy and incident
    *  angles.) and the direction in the local coordinate system (see
    * @GeometryInterface)
    */
-
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output) = 0;
+  { t.prepareInput(aFastTrack, localDir, inputs, tensDims, output) } -> std::same_as<void>;
 
   /** interpreting the model output and create a vector of spacepoints per layer
    * in local coordinates - with the origin at the entry point into the
    * calorimeter.
    */
-  virtual void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir,
-                             const std::vector<float>& output, std::vector<SpacePointVec>& spacepoints) = 0;
+  { t.convertOutput(aFastTrack, localDir, constOutput, spacepoints) } -> std::same_as<void>;
 };
 
 } // namespace ddml

--- a/include/DDML/ModelInterface.h
+++ b/include/DDML/ModelInterface.h
@@ -1,8 +1,8 @@
 #ifndef ModelInterface_H
 #define ModelInterface_H
 
-#include <vector>
 #include <concepts>
+#include <vector>
 
 #include "DDML/DDML.h"
 
@@ -17,9 +17,9 @@ namespace ddml {
  *  @author F.Gaede, DESY
  *  @date Mar 2023
  */
-template<typename T>
-concept ModelInterface = requires(T t, G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, 
-                                  InputVecs& inputs, TensorDimVecs& tensDims, std::vector<float>& output,
+template <typename T>
+concept ModelInterface = requires(T t, G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                                  TensorDimVecs& tensDims, std::vector<float>& output,
                                   const std::vector<float>& constOutput, std::vector<SpacePointVec>& spacepoints) {
   /** prepare the input vector and resize the output vector for this model
    *  based on the current FastTrack (e.g. extract kinetic energy and incident

--- a/include/DDML/ONNXInference.h
+++ b/include/DDML/ONNXInference.h
@@ -17,7 +17,7 @@ namespace ddml {
  *  @date Mar 2023
  */
 
-class ONNXInference : public InferenceInterface {
+class ONNXInference {
 public:
   ONNXInference();
 
@@ -30,7 +30,7 @@ public:
   void initialize();
 
   /// run the inference model - based on input vector and resized outputvector
-  virtual void runInference(const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output);
+  void runInference(const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output);
 
 private:
   /// Pointer to the ONNX enviroment
@@ -56,6 +56,8 @@ private:
   int m_optimizeFlag = 0;
   int m_intraOpNumThreads = 0;
 };
+
+static_assert(InferenceInterface<ONNXInference>, "ONNXInference must satisfy InferenceInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/OctogonalBarrelTrigger.h
+++ b/include/DDML/OctogonalBarrelTrigger.h
@@ -16,16 +16,19 @@ namespace ddml {
  *
  */
 
-class OctogonalBarrelTrigger : public TriggerInterface {
+class OctogonalBarrelTrigger {
 public:
   OctogonalBarrelTrigger() = default;
 
-  virtual ~OctogonalBarrelTrigger() = default;
+  ~OctogonalBarrelTrigger() = default;
 
   // check trigger
-
-  virtual bool check_trigger(const G4FastTrack& aFastTrack);
+  bool check_trigger(const G4FastTrack& aFastTrack) const;
 };
+
+// Ensure this class models the TriggerInterface concept
+static_assert(TriggerInterface<OctogonalBarrelTrigger>,
+              "OctogonalBarrelTrigger should model the TriggerInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/Par04ExampleVAE.h
+++ b/include/DDML/Par04ExampleVAE.h
@@ -14,11 +14,11 @@ namespace ddml {
  *  @date May 2023
  */
 
-class Par04ExampleVAE : public ModelInterface {
+class Par04ExampleVAE {
 public:
   Par04ExampleVAE() = default;
 
-  virtual ~Par04ExampleVAE() = default;
+  ~Par04ExampleVAE() = default;
 
   /// declare the proerties needed for the plugin
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
@@ -37,13 +37,13 @@ public:
    *  angles.)
    */
 
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output);
+  void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                    TensorDimVecs& tensDims, std::vector<float>& output);
 
   /** create a vector of spacepoints per layer interpreting the model output
    */
-  virtual void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir,
-                             const std::vector<float>& output, std::vector<SpacePointVec>& spacepoints);
+  void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, const std::vector<float>& output,
+                     std::vector<SpacePointVec>& spacepoints);
 
 private:
   float m_initialEnergy = 0.;
@@ -57,6 +57,8 @@ private:
   float m_cellSizeZ = 3.4;     // mm - not used really
   TensorDimVecs m_tensDims = {{1, m_latentSize + 4}};
 };
+
+static_assert(ModelInterface<Par04ExampleVAE>, "Par04ExampleVAE must fulfill the ModelInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/PionCloudsModel.h
+++ b/include/DDML/PionCloudsModel.h
@@ -19,11 +19,11 @@ namespace ddml {
  *  @date Feb. 2025
  */
 
-class PionCloudsModel : public ModelInterface {
+class PionCloudsModel {
 public:
   PionCloudsModel() = default;
 
-  virtual ~PionCloudsModel() = default;
+  ~PionCloudsModel() = default;
 
   /// declare the proerties needed for the plugin
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
@@ -34,13 +34,13 @@ public:
    *  based on the current FastTrack (e.g. extract kinetic energy and incident
    *  angles.)
    */
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output);
+  void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                    TensorDimVecs& tensDims, std::vector<float>& output);
 
   /** create a vector of spacepoints per layer interpreting the model output
    */
-  virtual void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir,
-                             const std::vector<float>& output, std::vector<SpacePointVec>& spacepoints);
+  void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, const std::vector<float>& output,
+                     std::vector<SpacePointVec>& spacepoints);
 
 private:
   /// model properties for plugin
@@ -52,6 +52,8 @@ private:
 
   TensorDimVecs m_tensDims = {{1, 1}, {1, 1}, {1, 1}, {1, 3}};
 };
+
+static_assert(ModelInterface<PionCloudsModel>);
 
 } // namespace ddml
 #endif

--- a/include/DDML/PolyhedraBarrelGeometry.h
+++ b/include/DDML/PolyhedraBarrelGeometry.h
@@ -19,11 +19,11 @@ namespace ddml {
  *
  */
 
-class PolyhedraBarrelGeometry : public GeometryInterface {
+class PolyhedraBarrelGeometry {
 public:
   PolyhedraBarrelGeometry() { initialize(); };
 
-  virtual ~PolyhedraBarrelGeometry() = default;
+  ~PolyhedraBarrelGeometry() = default;
 
   /// initialize the plugin - after properties have been set
   void initialize();
@@ -45,7 +45,7 @@ public:
 
   /** convert the local spacepoints to global spacepoints
    */
-  virtual void localToGlobal(G4FastTrack const& aFastTrack, std::vector<SpacePointVec>& spacepoints) const;
+  void localToGlobal(G4FastTrack const& aFastTrack, std::vector<SpacePointVec>& spacepoints) const;
 
 protected:
   /// local helper
@@ -62,6 +62,10 @@ private:
   std::string m_hadDetector = {"HcalBarrel"};
   int m_nHadSymmetry = m_nSymmetry;
 };
+
+// Static assert to ensure PolyhedraBarrelGeometry models the GeometryInterface concept
+static_assert(GeometryInterface<PolyhedraBarrelGeometry>,
+              "PolyhedraBarrelGeomtry should model the GeometryInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/RegularGridBIBAEModel.h
+++ b/include/DDML/RegularGridBIBAEModel.h
@@ -19,11 +19,11 @@ namespace ddml {
  *  @date Apr. 2023
  */
 
-class RegularGridBIBAEModel : public ModelInterface {
+class RegularGridBIBAEModel {
 public:
   RegularGridBIBAEModel() = default;
 
-  virtual ~RegularGridBIBAEModel() = default;
+  ~RegularGridBIBAEModel() = default;
 
   /// declare the proerties needed for the plugin
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
@@ -41,13 +41,13 @@ public:
    *  based on the current FastTrack (e.g. extract kinetic energy and incident
    *  angles.)
    */
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output);
+  void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                    TensorDimVecs& tensDims, std::vector<float>& output);
 
   /** create a vector of spacepoints per layer interpreting the model output
    */
-  virtual void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir,
-                             const std::vector<float>& output, std::vector<SpacePointVec>& spacepoints);
+  void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, const std::vector<float>& output,
+                     std::vector<SpacePointVec>& spacepoints);
 
 private:
   /// model properties for plugin
@@ -65,6 +65,8 @@ private:
   int m_centerCellY = 12.;
   TensorDimVecs m_tensDims = {{1, 1}, {1, 1}, {1, 2}};
 };
+
+static_assert(ModelInterface<RegularGridBIBAEModel>, "RegularGridBIBAEModel must fulfill the ModelInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/RegularGridGANModel.h
+++ b/include/DDML/RegularGridGANModel.h
@@ -14,11 +14,11 @@ namespace ddml {
  *  @date Mar 2023
  */
 
-class RegularGridGANModel : public ModelInterface {
+class RegularGridGANModel {
 public:
   RegularGridGANModel() = default;
 
-  virtual ~RegularGridGANModel() = default;
+  ~RegularGridGANModel() = default;
 
   /// declare the proerties needed for the plugin
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
@@ -37,13 +37,13 @@ public:
    *  angles.)
    */
 
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output);
+  void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                    TensorDimVecs& tensDims, std::vector<float>& output);
 
   /** create a vector of spacepoints per layer interpreting the model output
    */
-  virtual void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir,
-                             const std::vector<float>& output, std::vector<SpacePointVec>& spacepoints);
+  void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, const std::vector<float>& output,
+                     std::vector<SpacePointVec>& spacepoints);
 
 private:
   /// model properties for plugin
@@ -55,6 +55,8 @@ private:
   float m_cellSizeY = 5.;
   TensorDimVecs m_tensDims = {{1, 100, 1, 1, 1}, {1, 1, 1, 1, 1}};
 };
+
+static_assert(ModelInterface<RegularGridGANModel>, "RegularGridGANModel must fulfill the ModelInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/RegularGridTwoAngleBIBAEModel.h
+++ b/include/DDML/RegularGridTwoAngleBIBAEModel.h
@@ -83,7 +83,8 @@ private:
   TensorDimVecs m_tensDims = {{1, 1}, {1, 1}, {1, 1}, {1, 3}};
 };
 
-static_assert(ModelInterface<RegularGridTwoAngleBIBAEModel>, "RegularGridTwoAngleBIBAEModel must fulfill the ModelInterface concept");
+static_assert(ModelInterface<RegularGridTwoAngleBIBAEModel>,
+              "RegularGridTwoAngleBIBAEModel must fulfill the ModelInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/RegularGridTwoAngleBIBAEModel.h
+++ b/include/DDML/RegularGridTwoAngleBIBAEModel.h
@@ -21,11 +21,11 @@ namespace ddml {
  *  @date Aug. 2023
  */
 
-class RegularGridTwoAngleBIBAEModel : public ModelInterface {
+class RegularGridTwoAngleBIBAEModel {
 public:
   RegularGridTwoAngleBIBAEModel() = default;
 
-  virtual ~RegularGridTwoAngleBIBAEModel() = default;
+  ~RegularGridTwoAngleBIBAEModel() = default;
 
   /// declare the proerties needed for the plugin
   void declareProperties(dd4hep::sim::Geant4Action* plugin) {
@@ -43,13 +43,13 @@ public:
    *  based on the current FastTrack (e.g. extract kinetic energy and incident
    *  angles.)
    */
-  virtual void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
-                            TensorDimVecs& tensDims, std::vector<float>& output);
+  void prepareInput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, InputVecs& inputs,
+                    TensorDimVecs& tensDims, std::vector<float>& output);
 
   /** create a vector of spacepoints per layer interpreting the model output
    */
-  virtual void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir,
-                             const std::vector<float>& output, std::vector<SpacePointVec>& spacepoints);
+  void convertOutput(G4FastTrack const& aFastTrack, G4ThreeVector const& localDir, const std::vector<float>& output,
+                     std::vector<SpacePointVec>& spacepoints);
 
 private:
   /// model properties for plugin
@@ -82,6 +82,8 @@ private:
 
   TensorDimVecs m_tensDims = {{1, 1}, {1, 1}, {1, 1}, {1, 3}};
 };
+
+static_assert(ModelInterface<RegularGridTwoAngleBIBAEModel>, "RegularGridTwoAngleBIBAEModel must fulfill the ModelInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/TorchInference.h
+++ b/include/DDML/TorchInference.h
@@ -17,7 +17,7 @@ namespace ddml {
  *  @date Mar 2023
  */
 
-class TorchInference : public InferenceInterface {
+class TorchInference {
 public:
   TorchInference();
 
@@ -30,7 +30,7 @@ public:
   void initialize();
 
   /// run the inference model - based on input vector and resized outputvector
-  virtual void runInference(const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output);
+  void runInference(const InputVecs& inputs, const TensorDimVecs& tensDims, std::vector<float>& output);
 
 private:
   torch::jit::script::Module m_jitModule;
@@ -44,6 +44,8 @@ private:
   int m_optimizeFlag = 0;
   int m_intraOpNumThreads = 0;
 };
+
+static_assert(InferenceInterface<TorchInference>, "TorchInference must satisfy InferenceInterface concept");
 
 } // namespace ddml
 #endif

--- a/include/DDML/TriggerInterface.h
+++ b/include/DDML/TriggerInterface.h
@@ -2,22 +2,21 @@
 #define TriggerInterface_H
 
 #include "DDML/DDML.h"
+#include <concepts>
 
 class G4FastTrack;
 
 namespace ddml {
 
-/** The basic interface for ML model trigger
+/** The basic concept for ML model trigger
  *
  * @author P.McKeown, DESY
  * @date Sep. 2023
  */
 
-class TriggerInterface {
-public:
-  virtual ~TriggerInterface() = default;
-
-  virtual bool check_trigger(const G4FastTrack&) = 0;
+template <typename T>
+concept TriggerInterface = requires(const T t, const G4FastTrack& track) {
+  { t.check_trigger(track) } -> std::convertible_to<bool>;
 };
 
 } // namespace ddml

--- a/src/EndcapTriggerTwoAngleBIBAE.cc
+++ b/src/EndcapTriggerTwoAngleBIBAE.cc
@@ -4,7 +4,7 @@
 
 namespace ddml {
 
-bool EndcapTriggerTwoAngleBIBAE::check_trigger(const G4FastTrack& aFastTrack) {
+bool EndcapTriggerTwoAngleBIBAE::check_trigger(const G4FastTrack& aFastTrack) const {
   G4ThreeVector direction = aFastTrack.GetPrimaryTrack()->GetMomentumDirection();
 
   G4double global_theta = direction.theta();

--- a/src/MLModelActions.cc
+++ b/src/MLModelActions.cc
@@ -33,86 +33,73 @@ namespace ddml {
 #ifdef DDML_USE_ONNX_INFERENCE
 /// a concrete model for regular grid GANs applied to the barrel calorimeter
 /// with ONNX
-typedef FastMLShower<FastMLModel<ddml::ONNXInference, ddml::RegularGridGANModel, ddml::PolyhedraBarrelGeometry,
-                                 Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::ONNXInference, ddml::RegularGridGANModel, ddml::PolyhedraBarrelGeometry>>
     RegularGridGANPolyhedraBarrelONNXModel;
 
 /// a concrete model for regular grid GANs applied to the endcap calorimeter
 /// with ONNX
-typedef FastMLShower<
-    FastMLModel<ddml::ONNXInference, ddml::RegularGridGANModel, ddml::EndcapGeometry, Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::ONNXInference, ddml::RegularGridGANModel, ddml::EndcapGeometry>>
     RegularGridGANEndcapONNXModel;
 
 /// Par04 example
-typedef FastMLShower<
-    FastMLModel<ddml::ONNXInference, ddml::Par04ExampleVAE, ddml::PolyhedraBarrelGeometry, Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::ONNXInference, ddml::Par04ExampleVAE, ddml::PolyhedraBarrelGeometry>>
     Par04ExampleVAEPolyhedraBarrelONNXModel;
 
 /// a concrete model for regular grid GANs applied to the endcap calorimeter
 /// with ONNX
-typedef FastMLShower<
-    FastMLModel<ddml::ONNXInference, ddml::Par04ExampleVAE, ddml::EndcapGeometry, Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::ONNXInference, ddml::Par04ExampleVAE, ddml::EndcapGeometry>>
     Par04ExampleVAEEndcapONNXModel;
 #endif
 
 #ifdef DDML_USE_TORCH_INFERENCE
 /// a concrete model for regular grid GANs applied to the barrel calorimeter
 /// with Torch
-typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridGANModel, ddml::PolyhedraBarrelGeometry,
-                                 Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridGANModel, ddml::PolyhedraBarrelGeometry>>
     RegularGridGANPolyhedraBarrelTorchModel;
 
 /// a concrete model for regular grid GANs applied to the endcap calorimeter
 /// with Torch
-typedef FastMLShower<
-    FastMLModel<ddml::TorchInference, ddml::RegularGridGANModel, ddml::EndcapGeometry, Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridGANModel, ddml::EndcapGeometry>>
     RegularGridGANEndcapTorchModel;
 
 /// Model for BIBAE regular grid inference in the barrel calorimeter with Torch
-typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridBIBAEModel, ddml::PolyhedraBarrelGeometry,
-                                 Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridBIBAEModel, ddml::PolyhedraBarrelGeometry>>
     RegularGridBIBAEPolyhedraBarrelTorchModel;
 
 /// Model for BIBAE regular grid inference in the endcap calorimeter with Torch
-typedef FastMLShower<
-    FastMLModel<ddml::TorchInference, ddml::RegularGridBIBAEModel, ddml::EndcapGeometry, Geant4FastHitMakerGlobal>>
+typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridBIBAEModel, ddml::EndcapGeometry>>
     RegularGridBIBAEEndcapTorchModel;
 
 /// Model for two angle BIBAE regular grid inference in the barrel calorimeter
 /// with Torch
-typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridTwoAngleBIBAEModel,
-                                 ddml::PolyhedraBarrelGeometry, Geant4FastHitMakerGlobal,
-                                 ddml::OctogonalBarrelTrigger>> // add ML trigger
+typedef FastMLShower<
+    FastMLModel<ddml::TorchInference, ddml::RegularGridTwoAngleBIBAEModel, ddml::PolyhedraBarrelGeometry,
+                ddml::OctogonalBarrelTrigger>> // add ML trigger
     RegularGridTwoAngleBIBAEModelPolyhedraBarrelTorchModel;
 
 /// Model for two angle BIBAE regular grid inference in the endcap calorimter
 /// with Torch
 typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::RegularGridTwoAngleBIBAEModel, ddml::EndcapGeometry,
-                                 Geant4FastHitMakerGlobal,
                                  ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
     RegularGridTwoAngleBIBAEModelEndcapTorchModel;
 
 /// CaloClouds Model for the barrel calorimeter with Torch
 typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::CaloCloudsTwoAngleModel, ddml::PolyhedraBarrelGeometry,
-                                 Geant4FastHitMakerGlobal,
                                  ddml::OctogonalBarrelTrigger>> // add ML trigger
     CaloCloudsTwoAngleModelPolyhedraBarrelTorchModel;
 
 /// CaloClouds Model for the endcap calorimeter with Torch
-typedef FastMLShower<
-    FastMLModel<ddml::TorchInference, ddml::CaloCloudsTwoAngleModel, ddml::EndcapGeometry, Geant4FastHitMakerGlobal,
-                ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
+typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::CaloCloudsTwoAngleModel, ddml::EndcapGeometry,
+                                 ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
     CaloCloudsTwoAngleModelEndcapTorchModel;
 
 /// L2L Flows Model
-typedef FastMLShower<
-    FastMLModel<ddml::TorchInference, ddml::L2LFlowsModel, ddml::PolyhedraBarrelGeometry, Geant4FastHitMakerGlobal,
-                ddml::OctogonalBarrelTrigger>> // add ML trigger
+typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::L2LFlowsModel, ddml::PolyhedraBarrelGeometry,
+                                 ddml::OctogonalBarrelTrigger>> // add ML trigger
     L2LFlowsModelPolyhedraBarrelTorchModel;
 /// L2L Flows Model
-typedef FastMLShower<
-    FastMLModel<ddml::TorchInference, ddml::L2LFlowsModel, ddml::EndcapGeometry, Geant4FastHitMakerGlobal,
-                ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
+typedef FastMLShower<FastMLModel<ddml::TorchInference, ddml::L2LFlowsModel, ddml::EndcapGeometry,
+                                 ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
     L2LFlowsModelEndcapTorchModel;
 #endif
 
@@ -120,23 +107,20 @@ typedef FastMLShower<
 /// Load from HDF5 file- as an example for the two angle BIBAE regular grid
 // Barrel
 typedef FastMLShower<FastMLModel<ddml::LoadHdf5, ddml::RegularGridTwoAngleBIBAEModel, ddml::PolyhedraBarrelGeometry,
-                                 Geant4FastHitMakerGlobal,
                                  ddml::OctogonalBarrelTrigger>> // add ML trigger
     LoadHDF5RegularGridTwoAngleBIBAEModelPolyhedraBarrel;
 // Endcap
-typedef FastMLShower<
-    FastMLModel<ddml::LoadHdf5, ddml::RegularGridTwoAngleBIBAEModel, ddml::EndcapGeometry, Geant4FastHitMakerGlobal,
-                ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
+typedef FastMLShower<FastMLModel<ddml::LoadHdf5, ddml::RegularGridTwoAngleBIBAEModel, ddml::EndcapGeometry,
+                                 ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
     LoadHDF5RegularGridTwoAngleBIBAEModelEndcap;
 
 /// Load from HDF5 file- as an example for Hadron showers from PionClouds
 // Barrel
-typedef FastMLShower<
-    FastMLModel<ddml::LoadHdf5, ddml::PionCloudsModel, ddml::PolyhedraBarrelGeometry, Geant4FastHitMakerGlobal,
-                ddml::OctogonalBarrelTrigger>> // add ML trigger
+typedef FastMLShower<FastMLModel<ddml::LoadHdf5, ddml::PionCloudsModel, ddml::PolyhedraBarrelGeometry,
+                                 ddml::OctogonalBarrelTrigger>> // add ML trigger
     LoadHDF5PionCloudsPCHadronModelPolyhedraBarrel;
 // Endcap // ENDCAP IS CURRENTLY NOT IMPLEMENTED!!!!
-typedef FastMLShower<FastMLModel<ddml::LoadHdf5, ddml::PionCloudsModel, ddml::EndcapGeometry, Geant4FastHitMakerGlobal,
+typedef FastMLShower<FastMLModel<ddml::LoadHdf5, ddml::PionCloudsModel, ddml::EndcapGeometry,
                                  ddml::EndcapTriggerTwoAngleBIBAE>> // add ML trigger
     LoadHDF5PionCloudsPCHadronModelEndcap;
 #endif

--- a/src/OctogonalBarrelTrigger.cc
+++ b/src/OctogonalBarrelTrigger.cc
@@ -4,7 +4,7 @@
 
 namespace ddml {
 
-bool OctogonalBarrelTrigger::check_trigger(const G4FastTrack& aFastTrack) {
+bool OctogonalBarrelTrigger::check_trigger(const G4FastTrack& aFastTrack) const {
   G4ThreeVector direction = aFastTrack.GetPrimaryTrack()->GetMomentumDirection();
 
   G4double global_phi = direction.phi();


### PR DESCRIPTION
BEGINRELEASENOTES
- Make all abstract base class interfaces concepts and use them instead, since we never use them in a way that would require abstract base classes
- Remove the `HitMaker` as a customization point from the `FastMLModel` since we always use the same in any case at the moment.

ENDRELEASENOTES

- [x] Includes #9 